### PR TITLE
Organize Pico W keypad/LED project and add wiring + architecture docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.13)
+
+include(pico_sdk_import.cmake)
+
+project(pico_w_keypad_led C CXX ASM)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+pico_sdk_init()
+
+add_executable(pico_w_keypad_led
+  src/main.cpp
+)
+
+target_include_directories(pico_w_keypad_led PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/include
+)
+
+# This project uses Arduino-style APIs in source logic.
+# Provide the relevant framework/library in your local toolchain.
+target_link_libraries(pico_w_keypad_led
+  pico_stdlib
+)
+
+pico_add_extra_outputs(pico_w_keypad_led)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
-# CODEX-WOKWI
+# Pico W Keypad-to-LED Controller
+
+A Raspberry Pi Pico W project that reads a 4x4 matrix keypad and controls 12 LEDs based on key presses. The firmware logic is preserved from the provided source and organized into a clean repository layout with documentation-first structure.
+
+## Features
+- 4x4 keypad input scanning via `Keypad` library
+- Direct LED control for keys `1..8` and `A..D`
+- Group controls:
+  - `9` = all blue LEDs ON
+  - `0` = all blue LEDs OFF
+  - `*` = all red LEDs ON
+  - `#` = all red LEDs OFF
+- Hardware documentation for Wokwi and real Pico W wiring
+
+## Repository Structure
+
+```text
+.
+├── CMakeLists.txt
+├── README.md
+├── docs/
+│   ├── architecture.md
+│   └── wiring.md
+├── include/
+└── src/
+    └── main.cpp
+```
+
+## Hardware Bill of Materials
+- Raspberry Pi Pico W (RP2040)
+- 4x4 membrane keypad
+- 12 LEDs (8 blue + 4 red)
+- 12 × 220Ω resistors (LED current limiting)
+- 4 × 1kΩ resistors (keypad pull-ups)
+- Breadboard/jumper wires
+
+## GPIO Summary
+See full mapping in [`docs/wiring.md`](docs/wiring.md).
+
+- Keypad columns: GP19, GP18, GP17, GP16
+- Keypad rows: GP26, GP22, GP21, GP20
+- LED outputs: GP11, GP10, GP9, GP8, GP7, GP6, GP5, GP4, GP3, GP2, GP28, GP27
+
+## Build and Flash (Pico SDK Layout)
+> Note: The source logic uses Arduino APIs (`pinMode`, `digitalWrite`, `delay`, `Keypad`). Ensure your build/runtime provides Arduino compatibility for RP2040, or adapt the toolchain layer only.
+
+1. Install Pico SDK prerequisites (if not already installed).
+2. Configure SDK path:
+   ```bash
+   export PICO_SDK_PATH=/path/to/pico-sdk
+   ```
+3. Build:
+   ```bash
+   mkdir -p build
+   cd build
+   cmake ..
+   make -j
+   ```
+4. Hold **BOOTSEL** on Pico W, connect USB, copy generated `.uf2` to the mass storage drive.
+
+## Run in Wokwi
+1. Create/open a Raspberry Pi Pico project in Wokwi.
+2. Paste the provided `diagram.json` wiring.
+3. Add this firmware source (`src/main.cpp`) in the simulator project.
+4. Ensure the simulation environment includes the `Keypad` library and Arduino-style runtime support.
+5. Start simulation and press keypad buttons to observe LED behavior.
+
+## Run on Real Hardware
+1. Wire exactly as documented in [`docs/wiring.md`](docs/wiring.md).
+2. Build firmware for your selected RP2040 runtime that supports `Keypad`.
+3. Flash UF2 to Pico W.
+4. Validate key-to-LED behavior:
+   - Press `1..8` for blue channel LEDs
+   - Press `A..D` for red channel LEDs
+   - Use `9/0/*/#` for bank operations
+
+## Wi-Fi Notes
+This firmware does **not** use Wi-Fi functionality, so no SSID/password or credential file is required.
+
+## Documentation
+- Wiring and pin map: [`docs/wiring.md`](docs/wiring.md)
+- Firmware architecture: [`docs/architecture.md`](docs/architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,34 @@
+# Firmware Architecture
+
+## High-Level Design
+The firmware is a single-module event loop:
+1. Initialize all LED GPIO pins as outputs and force OFF state in `setup()`.
+2. Poll keypad state in `loop()` with `keypad.getKey()`.
+3. If a key is pressed, execute a `switch` action that turns on/off one LED or a group of LEDs.
+4. Delay 10ms for scan pacing.
+
+## Source Layout
+- `src/main.cpp`: Core firmware logic (unchanged behavior from provided source).
+- `include/`: Reserved for future headers/extensions.
+- `docs/wiring.md`: Hardware connectivity and GPIO map.
+- `docs/architecture.md`: This design overview.
+
+## Input/Output Behavior
+### Inputs
+- Keypad keys: `0-9`, `A-D`, `*`, `#`.
+
+### Outputs
+- 12 individual LEDs mapped in `ledPins[]`.
+
+### Action Map
+- `1..8`: Turn ON corresponding blue LED.
+- `9`: Turn ON blue LED bank (indices `0..7`).
+- `0`: Turn OFF blue LED bank (indices `0..7`).
+- `A..D`: Turn ON corresponding red LED.
+- `*`: Turn ON red LED bank (indices `8..11`).
+- `#`: Turn OFF red LED bank (indices `8..11`).
+
+## Non-Functional Notes
+- No Wi-Fi APIs are used even though target is Pico W.
+- No credential handling required.
+- Logic is intentionally preserved as-is; there is no state reset on single-key ON events except via bank OFF keys (`0` and `#`).

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -1,0 +1,57 @@
+# Wiring and GPIO Mapping
+
+## Overview
+This project connects a **4x4 matrix keypad** and **12 LEDs** to a Raspberry Pi Pico W. Each LED is driven from a dedicated GPIO pin through a 220Ω resistor. The keypad rows and columns are wired directly to GPIO pins, with pull-up resistors on row lines to 3.3V.
+
+## Components (from `diagram.json`)
+- 1x Raspberry Pi Pico / Pico W-compatible board
+- 1x 4x4 membrane keypad
+- 12x LEDs
+  - 8 blue LEDs (labels 1-8)
+  - 4 red LEDs (labels A-D)
+- 12x 220Ω resistors (LED current limiting)
+- 4x 1kΩ resistors (keypad row pull-ups)
+- Jumper wires and common GND rail
+
+## Keypad GPIO Mapping
+| Keypad Signal | Pico GPIO |
+|---|---|
+| C1 | GP19 |
+| C2 | GP18 |
+| C3 | GP17 |
+| C4 | GP16 |
+| R1 | GP26 |
+| R2 | GP22 |
+| R3 | GP21 |
+| R4 | GP20 |
+
+### Row Pull-Ups
+Each row line (R1-R4) is also tied to 3V3 through a 1kΩ resistor network (rp1-rp4 in the diagram).
+
+## LED GPIO Mapping
+The firmware array maps LEDs in this exact order:
+
+| Firmware Index | Logical Label | Pico GPIO |
+|---|---|---|
+| ledPins[0] | 1 | GP11 |
+| ledPins[1] | 2 | GP10 |
+| ledPins[2] | 3 | GP9 |
+| ledPins[3] | 4 | GP8 |
+| ledPins[4] | 5 | GP7 |
+| ledPins[5] | 6 | GP6 |
+| ledPins[6] | 7 | GP5 |
+| ledPins[7] | 8 | GP4 |
+| ledPins[8] | A | GP3 |
+| ledPins[9] | B | GP2 |
+| ledPins[10] | C | GP28 |
+| ledPins[11] | D | GP27 |
+
+All LED cathodes are connected to GND.
+
+## Serial Monitor
+- GP0 -> Serial RX
+- GP1 -> Serial TX
+
+## Assumptions
+- The provided Wokwi JSON uses `wokwi-pi-pico` but pinout is Pico W-compatible for this project.
+- Keypad library scanning behavior depends on the runtime (Arduino core or compatible environment).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,81 @@
+#include <Keypad.h>
+
+const uint8_t LEDS = 12;
+const uint8_t ROWS = 4;
+const uint8_t COLS = 4;
+
+char keys[ROWS][COLS] = {
+  { '1', '2', '3', 'A' },
+  { '4', '5', '6', 'B' },
+  { '7', '8', '9', 'C' },
+  { '*', '0', '#', 'D' }
+};
+
+// Pins connected to LED1, LED2, LED3, ...LED12
+uint8_t ledPins[LEDS] = { 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 28, 27 };
+uint8_t rowPins[ROWS] = { 26, 22, 21, 20 }; // Pins connected to R1, R2, R3, R4
+uint8_t colPins[COLS] = { 19, 18, 17, 16 }; // Pins connected to C1, C2, C3, C4
+
+Keypad keypad = Keypad(makeKeymap(keys), rowPins, colPins, ROWS, COLS);
+
+void setup() {
+  for (uint8_t l = 0; l < LEDS; l++) {
+    pinMode(ledPins[l], OUTPUT);
+    digitalWrite(ledPins[l], LOW);
+  }
+}
+
+void loop() {
+  char key = keypad.getKey();
+
+  if (key != NO_KEY) {
+    switch (key) {
+      case '1': digitalWrite(ledPins[0], HIGH);
+        break;
+      case '2': digitalWrite(ledPins[1], HIGH);
+        break;
+      case '3': digitalWrite(ledPins[2], HIGH);
+        break;
+      case '4': digitalWrite(ledPins[3], HIGH);
+        break;
+      case '5': digitalWrite(ledPins[4], HIGH);
+        break;
+      case '6': digitalWrite(ledPins[5], HIGH);
+        break;
+      case '7': digitalWrite(ledPins[6], HIGH);
+        break;
+      case '8': digitalWrite(ledPins[7], HIGH);
+        break;
+      case '9':
+        for (uint8_t l = 0; l < 8; l++) {
+          digitalWrite(ledPins[l], HIGH);
+        }
+        break;
+      case '0':
+        for (uint8_t l = 0; l < 8; l++) {
+          digitalWrite(ledPins[l], LOW);
+        }
+        break;
+      case 'A': digitalWrite(ledPins[8], HIGH);
+        break;
+      case 'B': digitalWrite(ledPins[9], HIGH);
+        break;
+      case 'C': digitalWrite(ledPins[10], HIGH);
+        break;
+      case 'D': digitalWrite(ledPins[11], HIGH);
+        break;
+      case '*':
+        for (uint8_t l = 8; l < 12; l++) {
+          digitalWrite(ledPins[l], HIGH);
+        }
+        break;
+      case '#':
+        for (uint8_t l = 8; l < 12; l++) {
+          digitalWrite(ledPins[l], LOW);
+        }
+        break;
+    }
+  }
+
+  delay(10);
+}


### PR DESCRIPTION
### Motivation
- Provide a clean, reproducible Pico W project layout and comprehensive documentation derived from the provided firmware and Wokwi diagram.
- Make the hardware wiring, GPIO mapping, and firmware architecture explicit so the project is easy to simulate in Wokwi and to build/flash on real hardware.
- Preserve the original keypad-to-LED control logic exactly while normalizing repository structure for future extension.

### Description
- Added `src/main.cpp` containing the original keypad scanning and LED control logic with the same `Keypad` keymap, `ledPins[]`, `rowPins[]`, `colPins[]`, and runtime behavior.
- Added documentation files `docs/wiring.md` and `docs/architecture.md` that include the component list, Pico GPIO pin mapping, action map for keys, and high-level firmware flow.
- Added a top-level `CMakeLists.txt` and an empty `include/` directory to present a Pico SDK-compatible layout and documented the Arduino-API compatibility caveat in `README.md`. 
- Replaced the placeholder `README.md` with a full project overview, BOM, build/flash instructions (Pico SDK flow), Wokwi simulation notes, and a GPIO summary reflecting the `diagram.json` connections. 

### Testing
- Verified files were created and visible with repository and filesystem checks using `find` and listing commands, and all invoked commands exited with code 0. 
- Inspected file contents using paged output (`nl -ba`) to confirm the firmware and documentation were written as intended. 
- No automated unit tests are present for the firmware itself; the change is documentation and structure-focused and the runtime behavior of `src/main.cpp` was preserved exactly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f291406b108333b1829484f8afa0ab)